### PR TITLE
Update VGC mode label and improve Champions mode replay filtering

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -62,7 +62,7 @@ const Settings = () => {
 
 				<SettingsCheckbox
 					settingsKey="vgc_only"
-					label="VGC Mode (Only save VGC replays)"
+					label="VGC/Champions Mode (Only save VGC/Champions replays)"
 					checked={settings.vgc_only}
 					onChange={handleCheckboxChange}
 					disabled={settings.use_custom_replay_filter}

--- a/src/lib/showdown/showdown.ts
+++ b/src/lib/showdown/showdown.ts
@@ -57,8 +57,10 @@ app.receive = (data: string) => {
 		const roomId = getRoomIdFromData(data);
 		const room = replaysManager.getReplay(roomId);
 
+		const VGC_KEYWORDS = ['vgc', 'champions'];
+
 		if (settings.vgc_only) {
-			if (room && room.format && !room.format.toLowerCase().includes('vgc')) {
+			if (room && room.format && !VGC_KEYWORDS.some((keyword) => room.format?.toLowerCase().includes(keyword))) {
 				replaysManager.setRoomState(roomId, ReplayRoomState.Ignored);
 			}
 		} else if (settings.use_custom_replay_filter) {


### PR DESCRIPTION
This pull request updates the replay filtering logic and user interface to support both "VGC" and "Champions" formats, instead of only "VGC". The changes ensure that when the relevant setting is enabled, only replays matching either "VGC" or "Champions" are saved, and the setting label is updated to reflect this broader scope.

Replay filtering improvements:

* Updated the filtering logic in `showdown.ts` to check for both "vgc" and "champions" keywords in the replay format, ensuring that replays from either category are saved when the setting is enabled.

User interface update:

* Changed the label in the `SettingsCheckbox` component in `Settings.tsx` to "VGC/Champions Mode (Only save VGC/Champions replays)" to accurately describe the updated functionality.